### PR TITLE
ImgDepthMapper: return depth map from `make`

### DIFF
--- a/depthmappers/ImgDepthMapper.js
+++ b/depthmappers/ImgDepthMapper.js
@@ -15,7 +15,7 @@ Stereogram.ImgDepthMapper = Stereogram.DepthMapper.extend({
     canvas.width = this.img.width;
     canvas.height = this.img.height;
     context.drawImage(this.img, 0, 0, canvas.width, canvas.height);
-    this.depthMapFromCanvas(canvas);
+    return this.depthMapFromCanvas(canvas);
   },
 
   depthMapFromCanvas: function (canvas) {


### PR DESCRIPTION
The make function currently doesn't actually return the depth map it generates. This causes Stereogram.js to crash any time the ImgDepthMapper is used.